### PR TITLE
Renaming Swap to Transpose

### DIFF
--- a/src/background/copy.js
+++ b/src/background/copy.js
@@ -87,7 +87,7 @@ M.formats.textTabs = {
     }
 };
 
-M.formats.textTabsSwap = {
+M.formats.textTabsTranspose = {
     opts: {method: 'clipboard', withSelection: true, keepStyles: false, keepHidden: false},
     exec: function (t) {
         clipboard.copyText(asTabs(matrix.transpose(t.textMatrix())))
@@ -101,7 +101,7 @@ M.formats.textCSV = {
     }
 };
 
-M.formats.textCSVSwap = {
+M.formats.textCSVTranspose = {
     opts: {method: 'clipboard', withSelection: true, keepStyles: false, keepHidden: false},
     exec: function (t) {
         clipboard.copyText(asCSV(matrix.transpose(t.textMatrix())))

--- a/src/lib/preferences.js
+++ b/src/lib/preferences.js
@@ -25,11 +25,11 @@ var defaults = {
     'copy.format.enabled.richHTML': true,
     'copy.format.enabled.richHTMLCSS': true,
     'copy.format.enabled.textCSV': true,
-    'copy.format.enabled.textCSVSwap': true,
+    'copy.format.enabled.textCSVTranspose': true,
     'copy.format.enabled.textHTML': true,
     'copy.format.enabled.textHTMLCSS': true,
     'copy.format.enabled.textTabs': true,
-    'copy.format.enabled.textTabsSwap': true,
+    'copy.format.enabled.textTabsTranspose': true,
     'copy.format.enabled.textTextile': true,
 
     'copy.format.default.richHTMLCSS': true,
@@ -78,9 +78,9 @@ var copyFormats = [
         "desc": "Copy as tab-delimited text"
     },
     {
-        "id": "textTabsSwap",
-        "name": "Text+Swap",
-        "desc": "Copy as tab-delimited text, swap columns and rows"
+        "id": "textTabsTranspose",
+        "name": "Text+Transpose",
+        "desc": "Copy as tab-delimited text, transpose columns and rows"
     },
     {
         "id": "textCSV",
@@ -88,9 +88,9 @@ var copyFormats = [
         "desc": "Copy as comma-separated text"
     },
     {
-        "id": "textCSVSwap",
-        "name": "CSV+Swap",
-        "desc": "Copy as comma-separated text, swap columns and rows"
+        "id": "textCSVTranspose",
+        "name": "CSV+Transpose",
+        "desc": "Copy as comma-separated text, transpose columns and rows"
     },
     {
         "id": "textHTMLCSS",


### PR DESCRIPTION
After my first time using this extension, I noticed that "swap" is not
intuitive enough, I think "transpose" is the appropriate term for this
operation, and it is also the term used by spreadsheet software. The
README.md itself says “Swap (transpose) copy.”, which is another signal
that "swap" wasn't the best word choice.

In this commit, I just blindly rename Swap to Transpose. I haven't
tested the code in the browser, though. (But I don't expect any issue.)