### PR TITLE
Enhance selection visuals and enable copying for stat card numbers

### DIFF
--- a/src/content.sass
+++ b/src/content.sass
@@ -8,11 +8,13 @@ body[data-copytables-wait] *
     cursor: wait  $i
 
 [data-copytables-selected]:not([data-copytables-locked])
-    background: Highlight $i
+    background: adjust-color(Highlight, $alpha: -0.3) $i // 更深的背景颜色
+    outline: 1px solid Highlight $i // 添加边框
     transition: $no-trans
 
 [data-copytables-marked]:not([data-copytables-locked])
-    background: Highlight $i
+    background: adjust-color(Highlight, $alpha: -0.3) $i // 更深的背景颜色
+    outline: 1px solid Highlight $i // 添加边框
     transition: $no-trans
 
 $infobox-border: 9px
@@ -78,3 +80,13 @@ $infobox-color: $accent
         padding: 12px
         cursor: pointer
 
+    .copyable-stat
+        cursor: pointer
+        &:hover
+            background-color: transparentize(darken($infobox-color, 10), 0.03)
+        &.copied
+            background-color: transparentize(green, 0.3) !important
+            transition: background-color 0.2s ease-in-out
+        &.copy-failed
+            background-color: transparentize(red, 0.3) !important
+            transition: background-color 0.2s ease-in-out

--- a/src/content/infobox.js
+++ b/src/content/infobox.js
@@ -72,8 +72,10 @@ function html(items, sticky) {
     var h = [];
 
     items.forEach(function (item) {
-        if (item.message !== null)
-            h.push(' <b>' + item.title + '<i>' + item.message + '</i></b>');
+        if (item.message !== null) {
+            // Add a span with a class for styling and an event listener for copying
+            h.push(' <b class="copyable-stat" title="Click to copy">' + item.title + '<i class="value">' + item.message + '</i></b>');
+        }
     });
 
     h = h.join('');
@@ -95,8 +97,29 @@ function init() {
     document.body.appendChild(box);
 
     box.addEventListener('click', function (e) {
-        if (dom.tag(e.target) === 'SPAN')
+        if (dom.tag(e.target) === 'SPAN' && e.target.textContent === '×') { // Close button
             hide();
+        } else if (e.target.closest('.copyable-stat')) {
+            var statElement = e.target.closest('.copyable-stat');
+            var valueElement = statElement.querySelector('.value');
+            if (valueElement) {
+                var valueText = valueElement.textContent;
+                navigator.clipboard.writeText(valueText).then(function () {
+                    // Briefly indicate success
+                    statElement.classList.add('copied');
+                    setTimeout(function () {
+                        statElement.classList.remove('copied');
+                    }, 1000);
+                }).catch(function (err) {
+                    console.error('Failed to copy text: ', err);
+                    // Optionally, indicate failure to the user
+                    statElement.classList.add('copy-failed');
+                    setTimeout(function () {
+                        statElement.classList.remove('copy-failed');
+                    }, 1000);
+                });
+            }
+        }
     });
 
     return box;


### PR DESCRIPTION
- Modified `src/content/infobox.js` to add click-to-copy functionality to the statistical numbers in the infobox. Includes visual feedback for copy success/failure.
- Updated `src/content.sass` to:
    - Apply a darker background and a border to selected table cells for better visibility.
    - Add hover effects to copyable stat numbers.
    - Style the success/failure feedback messages for the copy action.